### PR TITLE
Follow golint initialisms rules

### DIFF
--- a/definitions.go
+++ b/definitions.go
@@ -56,7 +56,7 @@ type Artifact struct {
 	Description                  string
 	DisplayColor                 string
 	Expedite                     bool
-	FormattedID                  string `json:"FormattedID"`
+	FormattedID                  string
 	LastUpdateDate               string
 	LatestDiscussionAgeInMinutes int
 	Name                         string
@@ -260,7 +260,7 @@ type Defect struct {
 	Recycled             bool
 	ReleaseNote          bool
 	Resolution           string
-	SalesforceCaseID     string `json:"SalesforceCaseID"`
+	SalesforceCaseID     string
 	SalesforceCaseNumber string
 	Severity             string
 	State                string
@@ -384,7 +384,7 @@ type Milestone struct {
 	TargetProjectReference   reference      `json:"TargetProject"`   // Project
 
 	DisplayColor       string
-	FormattedID        string `json:"FormattedID"`
+	FormattedID        string
 	Name               string
 	Notes              string
 	TargetDate         string
@@ -399,7 +399,7 @@ type MilestoneQuery struct {
 
 type PersistableObject struct {
 	CreationDate string
-	ObjectID     int64 `json:"ObjectID"`
+	ObjectID     int64
 	VersionID    string
 }
 
@@ -527,7 +527,7 @@ type Subscription struct {
 	SessionTimeoutSeconds   int
 	StoryHierarchyEnabled   bool
 	StoryHierarchyType      string
-	SubscriptionID          int `json:"SubscriptionID"`
+	SubscriptionID          int
 	SubscriptionType        string
 }
 
@@ -652,7 +652,7 @@ type TypeDefinition struct {
 	Deletable    bool
 	DisplayName  string
 	ElementName  string
-	IDPrefix     string `json:"IDPrefix"`
+	IDPrefix     string
 	Name         string
 	Note         string
 	Queryable    bool
@@ -687,7 +687,7 @@ type User struct {
 	LastName               string
 	LastPasswordUpdateDate string
 	MiddleName             string
-	NetworkID              string `json:"NetworkID"`
+	NetworkID              string
 	OfficeLocation         string
 	OnpremLdapUsername     string
 	Phone                  string
@@ -723,7 +723,7 @@ type UserPermission struct {
 
 	UserReference reference `json:"User"` // User
 
-	CustomObjectID string `json:"CustomObjectID"`
+	CustomObjectID string
 	Name           string
 	Role           string
 }

--- a/definitions.go
+++ b/definitions.go
@@ -1,11 +1,11 @@
 package rally
 
 type reference struct {
-	ReferenceUrl string `json:"_ref"`
+	ReferenceURL string `json:"_ref"`
 }
 
 type queryReference struct {
-	ReferenceUrl string `json:"_ref"`
+	ReferenceURL string `json:"_ref"`
 	Count        int
 }
 
@@ -56,7 +56,7 @@ type Artifact struct {
 	Description                  string
 	DisplayColor                 string
 	Expedite                     bool
-	FormattedId                  string `json:"FormattedID"`
+	FormattedID                  string `json:"FormattedID"`
 	LastUpdateDate               string
 	LatestDiscussionAgeInMinutes int
 	Name                         string
@@ -148,7 +148,7 @@ type Build struct {
 	Number   string
 	Start    string
 	Status   string
-	Uri      string
+	URI      string
 }
 
 type BuildQuery struct {
@@ -168,7 +168,7 @@ type BuildDefinition struct {
 	Description string
 	LastStatus  string
 	Name        string
-	Uri         string
+	URI         string
 }
 
 type Change struct {
@@ -180,7 +180,7 @@ type Change struct {
 	Base            string
 	Extension       string
 	PathAndFilename string
-	Uri             string
+	URI             string
 }
 
 type ChangeQuery struct {
@@ -202,7 +202,7 @@ type Changeset struct {
 	Message         string
 	Name            string
 	Revision        string
-	Uri             string
+	URI             string
 }
 
 type ChangesetQuery struct {
@@ -260,7 +260,7 @@ type Defect struct {
 	Recycled             bool
 	ReleaseNote          bool
 	Resolution           string
-	SalesforceCaseId     string `json:"SalesforceCaseID"`
+	SalesforceCaseID     string `json:"SalesforceCaseID"`
 	SalesforceCaseNumber string
 	Severity             string
 	State                string
@@ -384,7 +384,7 @@ type Milestone struct {
 	TargetProjectReference   reference      `json:"TargetProject"`   // Project
 
 	DisplayColor       string
-	FormattedId        string `json:"FormattedID"`
+	FormattedID        string `json:"FormattedID"`
 	Name               string
 	Notes              string
 	TargetDate         string
@@ -399,8 +399,8 @@ type MilestoneQuery struct {
 
 type PersistableObject struct {
 	CreationDate string
-	ObjectId     int64 `json:"ObjectID"`
-	VersionId    string
+	ObjectID     int64 `json:"ObjectID"`
+	VersionID    string
 }
 
 type Project struct {
@@ -488,7 +488,7 @@ type SCMRepository struct {
 	Description string
 	Name        string
 	SCMType     string
-	Uri         string
+	URI         string
 }
 
 type SchedulableArtifact struct {
@@ -527,7 +527,7 @@ type Subscription struct {
 	SessionTimeoutSeconds   int
 	StoryHierarchyEnabled   bool
 	StoryHierarchyType      string
-	SubscriptionId          int `json:"SubscriptionID"`
+	SubscriptionID          int `json:"SubscriptionID"`
 	SubscriptionType        string
 }
 
@@ -652,7 +652,7 @@ type TypeDefinition struct {
 	Deletable    bool
 	DisplayName  string
 	ElementName  string
-	IdPrefix     string `json:"IDPrefix"`
+	IDPrefix     string `json:"IDPrefix"`
 	Name         string
 	Note         string
 	Queryable    bool
@@ -687,7 +687,7 @@ type User struct {
 	LastName               string
 	LastPasswordUpdateDate string
 	MiddleName             string
-	NetworkId              string `json:"NetworkID"`
+	NetworkID              string `json:"NetworkID"`
 	OfficeLocation         string
 	OnpremLdapUsername     string
 	Phone                  string
@@ -723,7 +723,7 @@ type UserPermission struct {
 
 	UserReference reference `json:"User"` // User
 
-	CustomObjectId string `json:"CustomObjectID"`
+	CustomObjectID string `json:"CustomObjectID"`
 	Name           string
 	Role           string
 }

--- a/rally.go
+++ b/rally.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 )
 
-const apiUrl = "https://rally1.rallydev.com/slm/webservice/v2.0/"
+const apiURL = "https://rally1.rallydev.com/slm/webservice/v2.0/"
 const apiSessionKey = "ZSESSIONID"
 
 type rally struct {
@@ -24,7 +24,7 @@ type rally struct {
 //
 // Basic auth with username and password is not supported at the moment
 func New(token string) *rally {
-	return &rally{url: apiUrl, token: token}
+	return &rally{url: apiURL, token: token}
 }
 
 // Get a populated instance of the supplied object given the id
@@ -32,7 +32,7 @@ func (r *rally) Get(object interface{}, id string) error {
 	kind := getStructType(object)
 
 	parts := []string{strings.ToLower(kind), "/", id}
-	url := r.generateUrl(strings.Join(parts, ""))
+	url := r.generateURL(strings.Join(parts, ""))
 
 	body, err := r.get(url)
 	if err != nil {
@@ -47,12 +47,12 @@ func (r *rally) Get(object interface{}, id string) error {
 func (r *rally) Fetch(object interface{}, ref reference) error {
 	kind := getStructType(object)
 
-	if len(ref.ReferenceUrl) == 0 {
+	if len(ref.ReferenceURL) == 0 {
 		message := fmt.Sprintf("null reference for: %s", kind)
 		return errors.New(message)
 	}
 
-	body, err := r.get(ref.ReferenceUrl)
+	body, err := r.get(ref.ReferenceURL)
 	if err != nil {
 		return err
 	}
@@ -63,13 +63,13 @@ func (r *rally) Fetch(object interface{}, ref reference) error {
 // Fetch a populated query instance of the supplied query object given the
 // query reference supplied
 func (r *rally) QueryFetch(object interface{}, ref queryReference) error {
-	if len(ref.ReferenceUrl) == 0 {
+	if len(ref.ReferenceURL) == 0 {
 		kind := getStructType(object)
 		message := fmt.Sprintf("null query reference for: %s", kind)
 		return errors.New(message)
 	}
 
-	body, err := r.get(ref.ReferenceUrl)
+	body, err := r.get(ref.ReferenceURL)
 	if err != nil {
 		return err
 	}
@@ -78,7 +78,7 @@ func (r *rally) QueryFetch(object interface{}, ref queryReference) error {
 }
 
 // Concatinates the api url with the supplied uri
-func (r *rally) generateUrl(uri string) string {
+func (r *rally) generateURL(uri string) string {
 	var buffer bytes.Buffer
 
 	buffer.WriteString(r.url)

--- a/rally_test.go
+++ b/rally_test.go
@@ -45,7 +45,7 @@ func TestFetch(t *testing.T) {
 	rally := New(token)
 
 	var hr HierarchicalRequirement
-	hr.WorkspaceReference.ReferenceUrl = s.URL + expected
+	hr.WorkspaceReference.ReferenceURL = s.URL + expected
 
 	var w Workspace
 	rally.Fetch(&w, hr.WorkspaceReference)
@@ -63,7 +63,7 @@ func TestQueryFetch(t *testing.T) {
 	rally := New(token)
 
 	var hr HierarchicalRequirement
-	hr.TasksQueryReference.ReferenceUrl = s.URL + expected
+	hr.TasksQueryReference.ReferenceURL = s.URL + expected
 
 	var tq TaskQuery
 	rally.QueryFetch(&tq, hr.TasksQueryReference)
@@ -73,7 +73,7 @@ func TestQueryFetch(t *testing.T) {
 	assert.Equal(t, "Task 5", tq.Results[4].Name)
 }
 
-func TestFailFetchReferenceUrlEmpty(t *testing.T) {
+func TestFailFetchReferenceURLEmpty(t *testing.T) {
 
 	rally := New(token)
 
@@ -84,7 +84,7 @@ func TestFailFetchReferenceUrlEmpty(t *testing.T) {
 	assert.NotEmpty(t, err)
 }
 
-func TestFailQueryFetchReferenceUrlEmpty(t *testing.T) {
+func TestFailQueryFetchReferenceURLEmpty(t *testing.T) {
 
 	rally := New(token)
 
@@ -112,7 +112,7 @@ func TestFailClientDoRequest(t *testing.T) {
 
 	var a Artifact
 	var r reference
-	r.ReferenceUrl = "reference_url"
+	r.ReferenceURL = "reference_url"
 
 	err := rally.Fetch(&a, r)
 	assert.NotEmpty(t, err)
@@ -131,7 +131,7 @@ func TestFailStatusCodeNotOK(t *testing.T) {
 
 	var a Artifact
 	var q queryReference
-	q.ReferenceUrl = s.URL
+	q.ReferenceURL = s.URL
 
 	err := rally.QueryFetch(&a, q)
 	assert.NotEmpty(t, err)


### PR DESCRIPTION
- Edited code to follow the [initialism ruleset](https://github.com/golang/go/wiki/CodeReviewComments#initialisms)

`golint` is still complaining about exported structs not being commented, but I thought this would be a kick in the right direction.
