### PR TITLE
Add UserQuery type

### DIFF
--- a/definitions.go
+++ b/definitions.go
@@ -700,6 +700,12 @@ type User struct {
 	WorkspacePermission    string
 }
 
+type UserQuery struct {
+	queryResult
+
+	Results []User
+}
+
 type UserIterationCapacity struct {
 	WorkspaceDomainObject
 


### PR DESCRIPTION
Fix for #5 
> UserQuery type is missing in definitions.go.